### PR TITLE
Add Identity to Context to support inspecting cognito identities

### DIFF
--- a/apex.go
+++ b/apex.go
@@ -35,6 +35,13 @@ type Context struct {
 	MemoryLimitInMB          string          `json:"memoryLimitInMB"`
 	IsDefaultFunctionVersion bool            `json:"isDefaultFunctionVersion"`
 	ClientContext            json.RawMessage `json:"clientContext"`
+	Identity                 Identity        `json:"identity,omitempty"`
+}
+
+// As defined in: http://docs.aws.amazon.com/mobile/sdkforandroid/developerguide/lambda.html#identity-context
+type Identity struct {
+	CognitoIdentityId       string `json:"cognitoIdentityId"`
+	CognitoIdentityIdPoolId string `json:"cognitoIdentityPoolId"`
 }
 
 // Handle Lambda events with the given handler.


### PR DESCRIPTION
When using Cognito with a supported SDK (Currently Javascript, Mobile and Java I think) an additional context property is set `identity` this contains 2 sub properties `cognitoIdentityId` and `cognitoIdentityPoolId` as defined in (note the docs are out of date in terms of what SDK's support it):
[http://docs.aws.amazon.com/mobile/sdkforandroid/developerguide/lambda.html#identity-context](http://docs.aws.amazon.com/mobile/sdkforandroid/developerguide/lambda.html#identity-context)

Obviously when your not using Cognito with your SDK the property is not set hence the `,omitempty`. I've tested this with the javascript SDK and soon will be testing it with the Mobile SDK, heres a log dump straight from CloudWatch dumping the context object:

```
/aws/lambda/xxxxxx-xxxx-prototype_token-exchange Context: &{InvokeID:6a562e8b-3247-11e6-8d60-63d363c8a763 RequestID:6a562e8b-3247-11e6-8d60-63d363c8a763 FunctionName:xxxxxx-xxxx-prototype_token-exchange FunctionVersion:$LATEST LogGroupName:/aws/lambda/xxxxxx-xxxx-prototype_token-exchange LogStreamName:2016/06/14/[$LATEST]c7e475ceb1c749c1b7f899eecf7d851b MemoryLimitInMB:128 IsDefaultFunctionVersion:false ClientContext:[] Identity:{CognitoIdentityId:eu-west-1:905edd66-3ffe-4748-8511-05199ff46b31 CognitoIdentityIdPoolId:eu-west-1:715601c9-4f9d-4cb1-a749-32173f79a25e}}
```

Let me know if you have any questions.
