### PR TITLE
use AWS SDK type for DynamoDb events, document usage

### DIFF
--- a/_examples/dynamo/README.md
+++ b/_examples/dynamo/README.md
@@ -1,0 +1,21 @@
+# DynamoDB Example
+
+The example program receives a DynamoDB event and prints a specific attribute's value to stdout.
+
+## Setup
+
+Run the program locally:
+
+```
+go run main.go < event.json
+```
+
+## Unmarshaling DynamoDB Records
+
+DynamoDB uses a somewhat awkward notation to represent Attributes and Values in the event. It's a straight representation of the DynamoDB JSON which needs to be parsed to be useful.
+
+In the example the [AWS Go SDK](http://aws.amazon.com/sdk-for-go/) is used to Unmarshal the Dynamo Attributes. These are stored in the struct `newImage`.
+
+Depending on the event settings you could also Unmarshal `record.Dynamodb.OldImage` as needed.
+
+This method of Unmarshalling is optional you may elect to handle `record.Dynamodb.NewImage` (etc) in another way.

--- a/_examples/dynamo/event.json
+++ b/_examples/dynamo/event.json
@@ -1,0 +1,52 @@
+{
+  "event": {
+    "Records": [
+      {
+        "eventID": "1",
+        "eventVersion": "1.0",
+        "dynamodb": {
+          "Keys": {
+            "ExampleKey": {
+              "S": "foo"
+            }
+          },
+          "NewImage": {
+            "ExampleKey": {
+              "S": "bar"
+            }
+          },
+          "StreamViewType": "NEW_AND_OLD_IMAGES",
+          "SequenceNumber": "111",
+          "SizeBytes": 26
+        },
+        "awsRegion": "us-west-2",
+        "eventName": "INSERT",
+        "eventSourceARN": "arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+        "eventSource": "aws:dynamodb"
+      },
+      {
+        "eventID": "2",
+        "eventVersion": "1.0",
+        "dynamodb": {
+          "SequenceNumber": "222",
+          "Keys": {
+            "ExampleKey": {
+              "S": "fix"
+            }
+          },
+          "SizeBytes": 59,
+          "NewImage": {
+            "ExampleKey": {
+              "S": "qix"
+            }
+          },
+          "StreamViewType": "NEW_AND_OLD_IMAGES"
+        },
+        "awsRegion": "us-west-2",
+        "eventName": "INSERT",
+        "eventSourceARN": "arn:aws:dynamodb:us-west-2:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+        "eventSource": "aws:dynamodb"
+      }
+    ]
+  }
+}

--- a/_examples/dynamo/main.go
+++ b/_examples/dynamo/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/apex/go-apex"
+	"github.com/apex/go-apex/dynamo"
+	"github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute"
+)
+
+type newImage struct {
+	ExampleKey string
+}
+
+func main() {
+	dynamo.HandleFunc(func(event *dynamo.Event, ctx *apex.Context) error {
+		// Iterate all event records
+		for _, record := range event.Records {
+
+			// only act on INSERTs
+			if record.EventName == "INSERT" {
+
+				n := newImage{}
+				// Unmarshal the data for NewImage
+				dynamodbattribute.UnmarshalMap(record.Dynamodb.NewImage, &n)
+
+				// Print the example attribute. (Don't do this in your function!)
+				fmt.Println(n.ExampleKey)
+			}
+		}
+
+		return nil
+	})
+}

--- a/dynamo/dynamo.go
+++ b/dynamo/dynamo.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/apex/go-apex"
+	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
 )
 
 // Event represents a Dynamo event with one or more records.
@@ -14,24 +15,12 @@ type Event struct {
 
 // Record represents a single Dynamo record.
 type Record struct {
-	EventID      string `json:"eventID"`
-	EventName    string `json:"eventName"`
-	EventSource  string `json:"eventSource"`
-	EventVersion string `json:"eventVersion"`
-	AWSRegion    string `json:"awsRegion"`
-	Dynamodb     struct {
-		Keys struct {
-			ForumName struct {
-				S string `json:"S"`
-			} `json:"ForumName"`
-			Subject struct {
-				S string `json:"S"`
-			} `json:"Subject"`
-		} `json:"Keys"`
-		SequenceNumber string `json:"SequenceNumber"`
-		SizeBytes      int    `json:"SizeBytes"`
-		StreamViewType string `json:"StreamViewType"`
-	} `json:"dynamodb"`
+	EventID      string                        `json:"eventID"`
+	EventName    string                        `json:"eventName"`
+	EventSource  string                        `json:"eventSource"`
+	EventVersion string                        `json:"eventVersion"`
+	AWSRegion    string                        `json:"awsRegion"`
+	Dynamodb     *dynamodbstreams.StreamRecord `json:"dynamodb"`
 }
 
 // Handler handles Dynamo events.


### PR DESCRIPTION
As discussed in #17 

This PR:
- Uses an [AWS Go SDK](https://docs.aws.amazon.com/sdk-for-go/api/) type to parse DynamoDB events [`*dynamodbstreams.StreamRecord`](https://docs.aws.amazon.com/sdk-for-go/api/service/dynamodbstreams/#StreamRecord)
- Document usage including a method using the AWS SDK to unmarshal dynamic record attributes.
