### PR TITLE
Add Cognito UserPools helpers & an example with its function

### DIFF
--- a/_examples/cognito-userpools/README.md
+++ b/_examples/cognito-userpools/README.md
@@ -1,0 +1,11 @@
+# Cognito UserPools Example
+
+The example program receives a Cognito UserPools custom message event and prints it to stdout.
+
+## Setup
+
+Run the program locally:
+
+```
+go run main.go < event.json
+```

--- a/_examples/cognito-userpools/event.json
+++ b/_examples/cognito-userpools/event.json
@@ -1,0 +1,25 @@
+{
+  "event": {
+    "version": "1",
+    "region": "us-east-1",
+    "userPoolId": "us-east-1_XXXXXXXXX",
+    "userName": "user@example.com",
+    "triggerSource": "CustomMessage_SignUp",
+    "callerContext": {
+        "awsSdkVersion": "aws-sdk-xxx-1.0.0",
+        "clientId": "abcd1234efgh5678ijklm90123"
+    },
+    "request": {
+        "codeParameter": "9876",
+        "userAttributes": {
+            "email_verified": "false",
+            "phone_number_verified": "false"
+        }
+    },
+    "response": {
+        "emailSubject": null,
+        "emailMessage": null,
+        "smsMessage": null
+    }
+  }
+}

--- a/_examples/cognito-userpools/main.go
+++ b/_examples/cognito-userpools/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	apex "github.com/apex/go-apex"
+	idp "github.com/apex/go-apex/cognito-userpools"
+)
+
+func main() {
+	idp.CustomMessageHandleFunc(func(event *idp.CustomMessage, ctx *apex.Context) error {
+		code := event.Request.CodeParameter
+
+		switch event.TriggerSource {
+		case "CustomMessage_SignUp":
+			event.Response.EmailSubject = "Welcome to the service"
+			event.Response.EmailMessage = "Thank you for signing up. Your verification code is " + code
+			event.Response.SmsMessage = "Welcome to the service. Your verification code is " + code
+			break
+		case "CustomMessage_ForgotPassword":
+			event.Response.EmailSubject = "Verification code"
+			event.Response.EmailMessage = "Your verification code is " + code
+			event.Response.SmsMessage = "Your verification code is " + code
+			break
+		}
+		return nil
+	})
+}

--- a/cognito-userpools/idp-custom-message.go
+++ b/cognito-userpools/idp-custom-message.go
@@ -1,0 +1,63 @@
+package cognitouserpools
+
+import (
+	"encoding/json"
+
+	"github.com/apex/go-apex"
+)
+
+// CustomMessage represents a Cognito event.
+type CustomMessage struct {
+	CommonEvent
+	Request  CustomMessageRequest  `json:"request"`
+	Response CustomMessageResponse `json:"response"`
+}
+
+// CustomMessageRequest represents a Cognito user's status and the verification code.
+type CustomMessageRequest struct {
+	CodeParameter  string `json:"codeParameter"`
+	UserAttributes struct {
+		EmailVerified       string `json:"email_verified"`
+		PhoneNumberVerified string `json:"phone_number_verified"`
+	} `json:"userAttributes"`
+}
+
+// CustomMessageResponse represents a response to the cognito user.
+type CustomMessageResponse struct {
+	EmailSubject string `json:"emailSubject"`
+	EmailMessage string `json:"emailMessage"`
+	SmsMessage   string `json:"smsMessage"`
+}
+
+// CustomMessageHandler handles Cognito events.
+type CustomMessageHandler interface {
+	HandleCustomMessage(*CustomMessage, *apex.Context) error
+}
+
+// CustomMessageHandlerFunc unmarshals Cognito CustomMessage events before passing control.
+type CustomMessageHandlerFunc func(*CustomMessage, *apex.Context) error
+
+// Handle implements apex.Handler.
+func (h CustomMessageHandlerFunc) Handle(data json.RawMessage, ctx *apex.Context) (interface{}, error) {
+	var event CustomMessage
+
+	if err := json.Unmarshal(data, &event); err != nil {
+		return nil, err
+	}
+
+	if err := h(&event, ctx); err != nil {
+		return nil, err
+	}
+
+	return event, nil
+}
+
+// CustomMessageHandleFunc handles Cognito events with callback function.
+func CustomMessageHandleFunc(h CustomMessageHandlerFunc) {
+	apex.Handle(h)
+}
+
+// CustomMessageHandle Cognito events with handler.
+func CustomMessageHandle(h CustomMessageHandler) {
+	CustomMessageHandleFunc(CustomMessageHandlerFunc(h.HandleCustomMessage))
+}

--- a/cognito-userpools/idp-custom-message_test.go
+++ b/cognito-userpools/idp-custom-message_test.go
@@ -1,0 +1,18 @@
+package cognitouserpools
+
+import (
+	"testing"
+
+	"github.com/apex/go-apex"
+	"github.com/stretchr/testify/assert"
+)
+
+// HandlerFunc apex.Handler assertion.
+var _ apex.Handler = CustomMessageHandlerFunc(func(event *CustomMessage, ctx *apex.Context) error {
+	return nil
+})
+
+func Test(t *testing.T) {
+	assert.Nil(t, nil)
+	// TODO: unmarshalling test
+}

--- a/cognito-userpools/idp.go
+++ b/cognito-userpools/idp.go
@@ -1,0 +1,15 @@
+// Package cognitouserpools provides structs for working with AWS Cognito User Pools records.
+package cognitouserpools
+
+// CommonEvent represents a Cognito event.
+type CommonEvent struct {
+	Version       string `json:"version"`
+	Region        string `json:"region"`
+	UserPoolID    string `json:"userPoolId"`
+	UserName      string `json:"userName"`
+	TriggerSource string `json:"triggerSource"`
+	CallerContext struct {
+		AwsSdkVersion string `json:"awsSdkVersion"`
+		ClientID      string `json:"clientId"`
+	} `json:"callerContext"`
+}


### PR DESCRIPTION
Hi tj, I also try to add helpers for Cognito UserPools. Although there are several event JSONs, I've just implemented a helper for `custom message` trigger, which is most important I think.
http://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-identity-pools-working-with-aws-lambda-triggers.html
