### PR TITLE
Create dynamo.StreamRecord to avoid json.Unmarshall issue

### DIFF
--- a/dynamo/dynamo.go
+++ b/dynamo/dynamo.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 
 	"github.com/apex/go-apex"
-	"github.com/aws/aws-sdk-go/service/dynamodbstreams"
+	"github.com/aws/aws-sdk-go/service/dynamodb"
 )
 
 // Event represents a Dynamo event with one or more records.
@@ -15,12 +15,23 @@ type Event struct {
 
 // Record represents a single Dynamo record.
 type Record struct {
-	EventID      string                        `json:"eventID"`
-	EventName    string                        `json:"eventName"`
-	EventSource  string                        `json:"eventSource"`
-	EventVersion string                        `json:"eventVersion"`
-	AWSRegion    string                        `json:"awsRegion"`
-	Dynamodb     *dynamodbstreams.StreamRecord `json:"dynamodb"`
+	EventID      string        `json:"eventID"`
+	EventName    string        `json:"eventName"`
+	EventSource  string        `json:"eventSource"`
+	EventVersion string        `json:"eventVersion"`
+	AWSRegion    string        `json:"awsRegion"`
+	Dynamodb     *StreamRecord `json:"dynamodb"`
+}
+
+// StreamRecord represents a Dynamo stream records
+type StreamRecord struct {
+	ApproximateCreationDateTime int64
+	Keys                        map[string]*dynamodb.AttributeValue
+	NewImage                    map[string]*dynamodb.AttributeValue
+	OldImage                    map[string]*dynamodb.AttributeValue
+	SequenceNumber              string
+	SizeBytes                   int64
+	StreamViewType              string
 }
 
 // Handler handles Dynamo events.


### PR DESCRIPTION
The current use of dynamodbstreams.StreamRecord causes an error when the dynamo.Handle function tries to json.Unmarshall the data. This is because json.Unmarshall can't parse the unix timestamp as time.Time for ApproximateCreationDateTime.

Currently you get an error similar to this:

```
{"errorMessage":"parsing time \"1483585620\" as \"\"2006-01-02T15:04:05Z07:00\"\": cannot parse \"1483585620\" as \"\"\""}
```

There is an issue open for this on the aws-sdk-go repo [here](https://github.com/aws/aws-sdk-go/issues/796) however, it can easily be fixed from this side by defining our own StreamRecord. I left Keys, NewImage, OldImage as `map[string]*dynamodb.AttributeValue` because they json.Unmarshall just fine and it is convenient for using dynamodbattribute.UnmarshalMap to convert them into application specific types when handling the event.

There was also an issue for this on the go-apex repo [here](https://github.com/apex/go-apex/issues/37) but it is closed (I assume because the root cause is actually coming from the aws-sdk-go repo)