### PR TITLE
Add support for API Gateway Proxy requests

### DIFF
--- a/_examples/proxy/event.json
+++ b/_examples/proxy/event.json
@@ -1,0 +1,38 @@
+{
+  "event": {
+    "resource": "/{proxy+}",
+    "path": "/hello/world",
+    "httpMethod": "GET",
+    "headers": null,
+    "queryStringParameters": null,
+    "pathParameters": {
+      "proxy": "hello/world"
+    },
+    "stageVariables": null,
+    "requestContext": {
+      "accountId": "EXAMPLE",
+      "resourceId": "EXAMPLE",
+      "stage": "test-invoke-stage",
+      "requestId": "test-invoke-request",
+      "identity": {
+        "cognitoIdentityPoolId": null,
+        "accountId": "EXAMPLE",
+        "cognitoIdentityId": null,
+        "caller": "EXAMPLE",
+        "apiKey": "test-invoke-api-key",
+        "sourceIp": "test-invoke-source-ip",
+        "accessKey": "EXAMPLE",
+        "cognitoAuthenticationType": null,
+        "cognitoAuthenticationProvider": null,
+        "userArn": "arn:aws:iam::EXAMPLE:root",
+        "userAgent": "Apache-HttpClient/4.5.x (Java/1.8.0_102)",
+        "user": "EXAMPLE"
+      },
+      "resourcePath": "/{proxy+}",
+      "httpMethod": "GET",
+      "apiId": "EXAMPLE"
+    },
+    "body": null,
+    "isBase64Encoded": false
+  }
+}

--- a/_examples/proxy/main.go
+++ b/_examples/proxy/main.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"net/http"
+	"path"
+
+	"github.com/apex/go-apex"
+	"github.com/apex/go-apex/proxy"
+)
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", handleRoot)
+	mux.HandleFunc("/hello/", handleHello)
+
+	apex.Handle(proxy.Serve(mux))
+}
+
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Root"))
+}
+
+func handleHello(w http.ResponseWriter, r *http.Request) {
+	_, name := path.Split(r.URL.Path)
+	w.Write([]byte("Hello " + name))
+}

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -34,8 +34,15 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 
 ## Notes
-As with any Apex handler, you must make sure that your handler doesn't write anything to stdout. If your web framework logs to stdout by default, such as Martini, you need to change the logger output to use stderr.
+As with any Apex handler, you must make sure that your handler doesn't write anything to stdout. 
+If your web framework logs to stdout by default, such as Martini, you need to change the logger output to use stderr.
 
+Any output with a Content-Type that doesn't match `text/*` will be Base64 encoded in the output record.
+In order for this to be returned from API Gateway correctly, you will need to enable binary support and
+map the content types containing binary data.
+
+In practice you can usually map all types as binary using the `*/*` pattern for binary support if you aren't using other
+API Gateway resources which conflict with this.
 
 ## Differences from eawsy
 This implementation reuses a large portion of the event definitions from the eawsy AWS Lambda projects:
@@ -43,6 +50,7 @@ This implementation reuses a large portion of the event definitions from the eaw
  * https://github.com/eawsy/aws-lambda-go-event
  * https://github.com/eawsy/aws-lambda-go-net
 
-However, it wraps a web application in an apex-compatible adapter which makes direct calls to an http.Handler instance rather than creating a fake `net.Conn` and marshalling/unmarshalling the request data.
+However, it wraps a web application in an apex-compatible adapter which makes direct calls to an http.Handler instance
+rather than creating a fake `net.Conn` and marshalling/unmarshalling the request data.
 
 A ResponseWriter implementation captures the response of the handler and constructs an API Gateway Proxy response.

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,48 @@
+
+# API Gateway Proxy request handling support
+
+This package provides an Apex-compatible handler for [proxy requests](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-set-up-simple-proxy.html).
+
+Each proxy request matches a wildcard path in AWS API Gateway, which is then converted to a standard `http.Request` before dispatching using the `http.Handler` interface.
+
+
+## Usage
+Any router or middleware framework supporting the `http.Handler` interface should be compatible with this adapter.
+
+~~~ go
+package main
+
+import (
+	"net/http"
+
+	"github.com/apex/go-apex"
+	"github.com/apex/go-apex/proxy"
+)
+
+func main() {
+	// Adapts a single function to the http.Handler interface
+	hf := http.HandlerFunc(handler)
+
+	// Handles incoming apex requests using the proxy adapter
+	apex.Handle(proxy.Serve(hf))
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	w.Write([]byte("Hello world"))
+}
+~~~
+
+
+## Notes
+As with any Apex handler, you must make sure that your handler doesn't write anything to stdout. If your web framework logs to stdout by default, such as Martini, you need to change the logger output to use stderr.
+
+
+## Differences from eawsy
+This implementation reuses a large portion of the event definitions from the eawsy AWS Lambda projects:
+
+ * https://github.com/eawsy/aws-lambda-go-event
+ * https://github.com/eawsy/aws-lambda-go-net
+
+However, it wraps a web application in an apex-compatible adapter which makes direct calls to an http.Handler instance rather than creating a fake `net.Conn` and marshalling/unmarshalling the request data.
+
+A ResponseWriter implementation captures the response of the handler and constructs an API Gateway Proxy response.

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -34,15 +34,32 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 
 ## Notes
+### Stdout vs Stderr
 As with any Apex handler, you must make sure that your handler doesn't write anything to stdout. 
 If your web framework logs to stdout by default, such as Martini, you need to change the logger output to use stderr.
 
-Any output with a Content-Type that doesn't match `text/*` will be Base64 encoded in the output record.
+### Content-Types passed through as plain text output:
+Any output with a Content-Type that doesn't match one of those listed below will be Base64 encoded in the output record.
 In order for this to be returned from API Gateway correctly, you will need to enable binary support and
 map the content types containing binary data.
 
 In practice you can usually map all types as binary using the `*/*` pattern for binary support if you aren't using other
 API Gateway resources which conflict with this.
+
+The text-mode Content-Type regular expressions used by default are:
+* text/.*
+* application/json
+* application/.*\+json
+* application/xml
+* application/.*\+xml
+
+You can override this by calling `proxy.SetTextContentTypes` with a list of regular expressions matching the types that should
+not be Base64 encoded.
+
+### Output encoding
+API gateway will automatically gzip-encode the output of your API, so it's not necessary to gzip the output of your webapp.
+
+If you use your own gzip encoding, it's likely to interfere with the Base64 output for text content types - this hasn't been tested.
 
 ## Differences from eawsy
 This implementation reuses a large portion of the event definitions from the eawsy AWS Lambda projects:

--- a/proxy/decoder.go
+++ b/proxy/decoder.go
@@ -1,0 +1,83 @@
+//
+// Copyright 2017 Alsanium, SAS. or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Originally from https://github.com/eawsy/aws-lambda-go-event/blob/master/service/lambda/runtime/event/apigatewayproxyevt/decoder.go
+// Changes (kothar - 2017-02):
+//   Relocated to go-apex/proxy
+
+package proxy
+
+import "encoding/json"
+
+type requestContextAlias RequestContext
+
+type authorizer map[string]string
+
+// UnmarshalJSON interprets the data as a dynamic map which may carry either a
+// Amazon Cognito set of claims or a custom set of attributes. It then choose
+// the good one at runtime and fill the authorizer with it.
+func (a *authorizer) UnmarshalJSON(data []byte) error {
+	var cognito struct {
+		Claims *map[string]string
+	}
+	var custom map[string]string
+
+	err := json.Unmarshal(data, &cognito)
+	if err != nil {
+		return err
+	}
+
+	if cognito.Claims != nil {
+		*a = authorizer(*cognito.Claims)
+		return nil
+	}
+
+	err = json.Unmarshal(data, &custom)
+	if err != nil {
+		return err
+	}
+
+	*a = authorizer(custom)
+	return nil
+}
+
+type jsonRequestContext struct {
+	*requestContextAlias
+	Authorizer authorizer
+}
+
+// UnmarshalJSON interprets data as a RequestContext with a special authorizer.
+// It then leverages type aliasing and struct embedding to fill RequestContext
+// with an usual map[string]string.
+func (rc *RequestContext) UnmarshalJSON(data []byte) error {
+	var jrc jsonRequestContext
+	if err := json.Unmarshal(data, &jrc); err != nil {
+		return err
+	}
+
+	*rc = *(*RequestContext)(jrc.requestContextAlias)
+	rc.Authorizer = jrc.Authorizer
+
+	return nil
+}
+
+// MarshalJSON reverts the effect of type aliasing and struct embedding used
+// during the marshalling step to make the pattern seamless.
+func (rc *RequestContext) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&jsonRequestContext{
+		(*requestContextAlias)(rc),
+		rc.Authorizer,
+	})
+}

--- a/proxy/event.go
+++ b/proxy/event.go
@@ -1,0 +1,159 @@
+//
+// Copyright 2017 Alsanium, SAS. or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Originally from https://github.com/eawsy/aws-lambda-go-event/blob/master/service/lambda/runtime/event/apigatewayproxyevt/definition.go
+// Changes (kothar - 2017-02):
+//   Relocated to go-apex/proxy
+
+package proxy
+
+import "encoding/json"
+
+// Identity provides identity information about the API caller.
+type Identity struct {
+	// The API owner key associated with the API.
+	APIKey string
+
+	// The AWS account ID associated with the request.
+	AccountID string
+
+	// The User Agent of the API caller.
+	UserAgent string
+
+	// The source IP address of the TCP connection making the request to
+	// Amazon API Gateway.
+	SourceIP string
+
+	// The Amazon Access Key associated with the request.
+	AccessKey string
+
+	// The principal identifier of the caller making the request.
+	// It is same as the User and interchangeable.
+	Caller string
+
+	// The principal identifier of the user making the request.
+	// It is same as the Caller and interchangeable.
+	User string
+
+	// The Amazon Resource Name (ARN) of the effective user identified after
+	// authentication.
+	UserARN string
+
+	// The Amazon Cognito identity ID of the caller making the request.
+	// Available only if the request was signed with Amazon Cognito credentials.
+	CognitoIdentityID string
+
+	// The Amazon Cognito identity pool ID of the caller making the request.
+	// Available only if the request was signed with Amazon Cognito credentials.
+	CognitoIdentityPoolID string
+
+	// The Amazon Cognito authentication type of the caller making the request.
+	// Available only if the request was signed with Amazon Cognito credentials.
+	CognitoAuthenticationType string
+
+	// The Amazon Cognito authentication provider used by the caller making the
+	// request.
+	// Available only if the request was signed with Amazon Cognito credentials.
+	CognitoAuthenticationProvider string
+}
+
+// RequestContext provides contextual information about an Amazon API Gateway
+// Proxy event.
+type RequestContext struct {
+	// The identifier Amazon API Gateway assigns to the API.
+	APIID string
+
+	// The identifier Amazon API Gateway assigns to the resource.
+	ResourceID string
+
+	// An automatically generated ID for the API call.
+	RequestID string
+
+	// The incoming request HTTP method name.
+	// Valid values include: DELETE, GET, HEAD, OPTIONS, PATCH, POST, and PUT.
+	HTTPMethod string
+
+	// The resource path as defined in Amazon API Gateway.
+	ResourcePath string
+
+	// The AWS account ID associated with the API.
+	AccountID string
+
+	// The deployment stage of the API call (for example, Beta or Prod).
+	Stage string
+
+	// The API caller identification information.
+	Identity *Identity
+
+	// If used with Amazon Cognito, it represents the claims returned from the
+	// Amazon Cognito user pool after the method caller is successfully
+	// authenticated.
+	// If used with Amazon API Gateway custom authorizer, it represents the
+	// specified key-value pair of the context map returned from the custom
+	// authorizer AWS Lambda function.
+	Authorizer map[string]string `json:"-"`
+}
+
+// Event represents an Amazon API Gateway Proxy Event.
+type Event struct {
+	// The incoming request HTTP method name.
+	// Valid values include: DELETE, GET, HEAD, OPTIONS, PATCH, POST, and PUT.
+	HTTPMethod string
+
+	// The incoming reauest HTTP headers.
+	// Duplicate entries are not supported.
+	Headers map[string]string
+
+	// The resource path with raw placeholders as defined in Amazon API Gateway.
+	Resource string
+
+	// The incoming request path parameters corresponding to the resource path
+	// placeholders values as defined in Resource.
+	PathParameters map[string]string
+
+	// The real path corresponding to the path parameters injected into the
+	// Resource placeholders.
+	Path string
+
+	// The incoming request query string parameters.
+	// Duplicate entries are not supported.
+	QueryStringParameters map[string]string
+
+	// If used with Amazon API Gateway binary support, it represents the Base64
+	// encoded binary data from the client.
+	// Otherwise it represents the raw data from the client.
+	Body string
+
+	// A flag to indicate if the applicable request payload is Base64 encoded.
+	IsBase64Encoded bool
+
+	// The name-value pairs defined as configuration attributes associated with
+	// the deployment stage of the API.
+	StageVariables map[string]string
+
+	// The contextual information associated with the API call.
+	RequestContext *RequestContext
+}
+
+// String returns the string representation.
+func (e *Event) String() string {
+	s, _ := json.MarshalIndent(e, "", "  ")
+	return string(s)
+}
+
+// GoString returns the string representation.
+func (e *Event) GoString() string {
+	return e.String()
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,0 +1,46 @@
+package proxy
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/apex/go-apex"
+)
+
+// Serve adaptes an http.Handler to the apex.Handler interface
+func Serve(handler http.Handler) *Handler {
+	return &Handler{handler}
+}
+
+// Handler implements the apex.Handler interface and adapts it to an
+// http.Handler by converting the incoming event to an http.Request object
+type Handler struct {
+	Handler http.Handler
+}
+
+// Handle accepts a request from the apex shim and dispatches it to an http.Handler
+func (p *Handler) Handle(event json.RawMessage, ctx *apex.Context) (interface{}, error) {
+
+	// Parse the incoming proxy event from API Gateway
+	proxyEvent := &Event{}
+	err := json.Unmarshal(event, proxyEvent)
+	if err != nil {
+		return nil, fmt.Errorf("Parse proxy event: %s", err)
+	}
+
+	// Build an http.Request from the evnt
+	request, err := buildRequest(proxyEvent, ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Build request: %s", err)
+	}
+	responseWriter := &ResponseWriter{}
+
+	// Handle the request
+	p.Handler.ServeHTTP(responseWriter, request)
+
+	// Finish writing the response
+	responseWriter.finish()
+
+	return &responseWriter.response, nil
+}

--- a/proxy/request.go
+++ b/proxy/request.go
@@ -46,9 +46,9 @@ func buildRequest(proxyEvent *Event, ctx *apex.Context) (*http.Request, error) {
 
 	dec := proxyEvent.Body
 	if proxyEvent.IsBase64Encoded {
-		data, err := base64.StdEncoding.DecodeString(dec)
-		if err != nil {
-			return nil, fmt.Errorf("Decode base64 request body: %s", err)
+		data, err2 := base64.StdEncoding.DecodeString(dec)
+		if err2 != nil {
+			return nil, fmt.Errorf("Decode base64 request body: %s", err2)
 		}
 		dec = string(data)
 	}

--- a/proxy/request.go
+++ b/proxy/request.go
@@ -1,0 +1,78 @@
+//
+// Copyright 2017 Alsanium, SAS. or its affiliates. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Adapted from https://github.com/eawsy/aws-lambda-go-net/blob/master/service/lambda/runtime/net/apigatewayproxy/server.go
+// Changes (kothar - 2017-02):
+//   - Relocated to go-apex/proxy
+//   - All code not related to constructing an http.Request removed
+//   - Remaining code placed in buildRequest function
+
+package proxy
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/apex/go-apex"
+)
+
+// Constructs an http.Request object from a proxyEvent
+func buildRequest(proxyEvent *Event, ctx *apex.Context) (*http.Request, error) {
+	u, err := url.Parse(proxyEvent.Path)
+	if err != nil {
+		return nil, fmt.Errorf("Parse request path: %s", err)
+	}
+	q := u.Query()
+	for k, v := range proxyEvent.QueryStringParameters {
+		q.Set(k, v)
+	}
+	u.RawQuery = q.Encode()
+
+	dec := proxyEvent.Body
+	if proxyEvent.IsBase64Encoded {
+		data, err := base64.StdEncoding.DecodeString(dec)
+		if err != nil {
+			return nil, fmt.Errorf("Decode base64 request body: %s", err)
+		}
+		dec = string(data)
+	}
+
+	req, err := http.NewRequest(proxyEvent.HTTPMethod, u.String(), strings.NewReader(dec))
+	if err != nil {
+		return nil, fmt.Errorf("Create request: %s", err)
+	}
+
+	proxyEvent.Body = "... truncated"
+
+	for k, v := range proxyEvent.Headers {
+		req.Header.Set(k, v)
+	}
+	hbody, err := json.Marshal(proxyEvent)
+	if err != nil {
+		return nil, fmt.Errorf("Marshal proxy event: %s", err)
+	}
+	req.Header.Set("X-ApiGatewayProxy-Event", string(hbody))
+	if ctx != nil {
+		req.Header.Set("X-ApiGatewayProxy-Context", string(ctx.ClientContext))
+	}
+
+	req.Host = proxyEvent.Headers["Host"]
+
+	return req, nil
+}

--- a/proxy/responsewriter.go
+++ b/proxy/responsewriter.go
@@ -1,0 +1,97 @@
+package proxy
+
+import (
+	"bytes"
+	"net/http"
+)
+
+// Response defines parameters for a well formed response AWS Lambda should
+// return to Amazon API Gateway.
+// Originally from https://github.com/eawsy/aws-lambda-go-net/blob/master/service/lambda/runtime/net/apigatewayproxy/server.go
+type Response struct {
+	StatusCode      int               `json:"statusCode"`
+	Headers         map[string]string `json:"headers,omitempty"`
+	Body            string            `json:"body,omitempty"`
+	IsBase64Encoded bool              `json:"isBase64Encoded"`
+}
+
+// ResponseWriter implements the http.ResponseWriter interface and
+// collects the results of an HTTP request in an API Gateway proxy
+// response object.
+type ResponseWriter struct {
+	response       Response
+	output         bytes.Buffer
+	headers        http.Header
+	headersWritten bool
+}
+
+// Header returns the header map that will be sent by
+// WriteHeader. Changing the header after a call to
+// WriteHeader (or Write) has no effect unless the modified
+// headers were declared as trailers by setting the
+// "Trailer" header before the call to WriteHeader (see example).
+// To suppress implicit response headers, set their value to nil.
+func (w *ResponseWriter) Header() http.Header {
+	if w.headers == nil {
+		w.headers = make(http.Header)
+	}
+	return w.headers
+}
+
+// Write writes the data to the connection as part of an HTTP reply.
+//
+// If WriteHeader has not yet been called, Write calls
+// WriteHeader(http.StatusOK) before writing the data. If the Header
+// does not contain a Content-Type line, Write adds a Content-Type set
+// to the result of passing the initial 512 bytes of written data to
+// DetectContentType.
+//
+// Depending on the HTTP protocol version and the client, calling
+// Write or WriteHeader may prevent future reads on the
+// Request.Body. For HTTP/1.x requests, handlers should read any
+// needed request body data before writing the response. Once the
+// headers have been flushed (due to either an explicit Flusher.Flush
+// call or writing enough data to trigger a flush), the request body
+// may be unavailable. For HTTP/2 requests, the Go HTTP server permits
+// handlers to continue to read the request body while concurrently
+// writing the response. However, such behavior may not be supported
+// by all HTTP/2 clients. Handlers should read before writing if
+// possible to maximize compatibility.
+func (w *ResponseWriter) Write(bs []byte) (int, error) {
+	if !w.headersWritten {
+		w.WriteHeader(http.StatusOK)
+	}
+	return w.output.Write(bs)
+}
+
+// WriteHeader sends an HTTP response header with status code.
+// If WriteHeader is not called explicitly, the first call to Write
+// will trigger an implicit WriteHeader(http.StatusOK).
+// Thus explicit calls to WriteHeader are mainly used to
+// send error codes.
+func (w *ResponseWriter) WriteHeader(status int) {
+	if w.headersWritten {
+		return
+	}
+
+	w.response.StatusCode = status
+
+	finalHeaders := make(map[string]string)
+	for k, v := range w.headers {
+		if len(v) > 0 {
+			finalHeaders[k] = v[len(v)-1]
+		}
+	}
+
+	if value, ok := finalHeaders["Content-Type"]; !ok || value == "" {
+		finalHeaders["Content-Type"] = "text/html"
+	}
+	w.response.Headers = finalHeaders
+
+	w.headersWritten = true
+}
+
+// finish writes the accumulated output to the response.Body
+func (w *ResponseWriter) finish() {
+	w.response.Body = w.output.String()
+}


### PR DESCRIPTION
Closes #40

This implementation reuses a large portion of the event definitions here:
https://github.com/eawsy/aws-lambda-go-event
https://github.com/eawsy/aws-lambda-go-net

But wraps it in an apex-compatible handler, and also makes direct calls to an http.Handler instance rather than creating a fake net.Conn and marshalling/unmarshalling the request data.

A ResponseWriter implementation captures the response of the handler and constructs an API Gateway Proxy response.

Currently the response is not Base64 encoded, but this may be desirable if the output of the handler is binary to avoid excessive unicode escaping.