### PR TITLE
Add support for EventSourceARN

### DIFF
--- a/dynamo/dynamo.go
+++ b/dynamo/dynamo.go
@@ -15,12 +15,13 @@ type Event struct {
 
 // Record represents a single Dynamo record.
 type Record struct {
-	EventID      string        `json:"eventID"`
-	EventName    string        `json:"eventName"`
-	EventSource  string        `json:"eventSource"`
-	EventVersion string        `json:"eventVersion"`
-	AWSRegion    string        `json:"awsRegion"`
-	Dynamodb     *StreamRecord `json:"dynamodb"`
+	EventID        string        `json:"eventID"`
+	EventName      string        `json:"eventName"`
+	EventSource    string        `json:"eventSource"`
+        EventSourceARN string        `json:"eventSourceARN"`
+	EventVersion   string        `json:"eventVersion"`
+	AWSRegion      string        `json:"awsRegion"`
+	Dynamodb       *StreamRecord `json:"dynamodb"`
 }
 
 // StreamRecord represents a Dynamo stream records

--- a/dynamo/dynamo.go
+++ b/dynamo/dynamo.go
@@ -18,7 +18,7 @@ type Record struct {
 	EventID        string        `json:"eventID"`
 	EventName      string        `json:"eventName"`
 	EventSource    string        `json:"eventSource"`
-        EventSourceARN string        `json:"eventSourceARN"`
+	EventSourceARN string        `json:"eventSourceARN"`
 	EventVersion   string        `json:"eventVersion"`
 	AWSRegion      string        `json:"awsRegion"`
 	Dynamodb       *StreamRecord `json:"dynamodb"`


### PR DESCRIPTION
Added support for an eventSourceARN.  This would enable lambda consumers to extract the name of the table that invoked the lambda function.