### PR TITLE
shim: boomerang ID from input to allow multiplexed output

### DIFF
--- a/apex.go
+++ b/apex.go
@@ -62,12 +62,17 @@ func HandleFunc(h HandlerFunc) {
 
 // input from the node shim.
 type input struct {
+	// ID is an itentifier that is boomeranged back to the called,
+	// to allow for concurrent commands
+	ID      string          `json:"id,omitempty"`
 	Event   json.RawMessage `json:"event"`
 	Context *Context        `json:"context"`
 }
 
 // output for the node shim.
 type output struct {
+	// The boomeranged ID from the caller
+	ID    string      `json:"id,omitempty"`
 	Error string      `json:"error,omitempty"`
 	Value interface{} `json:"value,omitempty"`
 }
@@ -98,7 +103,7 @@ func (m *manager) Start() {
 		}
 
 		v, err := m.Handler.Handle(msg.Event, msg.Context)
-		out := output{Value: v}
+		out := output{ID: msg.ID, Value: v}
 
 		if err != nil {
 			out.Error = err.Error()


### PR DESCRIPTION
Apex currently relies on the complete ordering of events on stdin and events over stdout.  It associates them together simply by their ordering.  While this is perhaps _currently_ correct, its correctness is based a lots of assumptions about lambda.  In addition, [future uses](https://github.com/apex/up/issues/339) of apex will require correct handling of concurrent requests.

To demonstrate, here is at least one case whose correctness depends on lambda behavior.

## Case 1, lambda reuses containers (and processes) who have timed out
1. **Request A** comes in, with lambda timeout 30 seconds.
1. **Request A** sends command A over stdin to go process
1. _30 seconds pass_, Lambda freezes the container and allows the it to be reused.
1. code is thawed, **Request B** comes in, and sends **command B** over stdin to go process
1. **Handler A** replies with **response A** over stdout
1. **response A** comes in to shim, **response A** is sent to **request B**
1. **response B** comes in, re-calls **callback B** ?? what happens here.

[this commit](https://github.com/apex/go-apex/commit/692062751de245c96f9390189d7c935e71322f7c) resolved a very subtle bug  in apex.Handler where the ordering of inputs weren't necessarily tied to the ordering of the outputs [because the outputs are generated in goroutines](https://github.com/apex/go-apex/blob/4a9f27263ec2fda6d10c900c107c6007fb75302c/apex.go#L128-L131).

This will require a similar change on the shim side.