### PR TITLE
resolves #59 - enables go functions to specify the errorType to support AWS Step Function retries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# ignore intellij files
+#
+.idea
+*.iml
+*.ipr
+*.iws


### PR DESCRIPTION
See bottom of:

http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-mode-exceptions.html