### PR TITLE
Add UserIdentity in DynamoDB record 

### DIFF
--- a/dynamo/dynamo.go
+++ b/dynamo/dynamo.go
@@ -22,6 +22,12 @@ type Record struct {
 	EventVersion   string        `json:"eventVersion"`
 	AWSRegion      string        `json:"awsRegion"`
 	Dynamodb       *StreamRecord `json:"dynamodb"`
+	UserIdentity   UserIdentity  `json:"userIdentity,omitempty"`
+}
+
+type UserIdentity struct {
+	Type        string `json:"type,omitempty"`
+	PrincipleID string `json:"principalId,omitempty"`
 }
 
 // StreamRecord represents a Dynamo stream records


### PR DESCRIPTION
When TTL is set to a DynamoDB record, `userIdentity` is set when retrieved via DynamoDB Streams. It is important to identify the deletion is due to the TTL expiration or not.

References:
- http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_streams_Record.html
- http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/time-to-live-ttl-streams.html

See also: https://github.com/aws/aws-sdk-go/pull/1110/files#diff-f2c14fc94d6994696a036c6d465c312fR863, https://github.com/aws/aws-sdk-go/blob/master/service/dynamodbstreams/api.go#L874-L920